### PR TITLE
remove unnecessary pass-by-reference

### DIFF
--- a/src/tutorial/02-adding-the-paddles.md
+++ b/src/tutorial/02-adding-the-paddles.md
@@ -157,7 +157,7 @@ We can then plug this field into our existing rendering code, so that the textur
 fn draw(&mut self, ctx: &mut Context) -> tetra::Result {
     graphics::clear(ctx, Color::rgb(0.392, 0.584, 0.929));
 
-    graphics::draw(ctx, &self.paddle_texture, &self.paddle_position);
+    graphics::draw(ctx, &self.paddle_texture, self.paddle_position);
 
     Ok(())
 }


### PR DESCRIPTION
Thanks again for writing the Pong tutorial. I went through it this morning and had a blast! :rocket: 

The only issue I encountered was passing `&self.paddle_position` by reference here seems to conflict with the `DrawParams` conversion. This was pretty easy to resolve but I wanted to share this back with you in case other people run into the same issue.

[Here is a repo](https://github.com/cbzehner/pong-tutorial-pass-by-reference) that follows the tutorial up until [Reacting to Input](https://tetra.seventeencups.net/tutorial/02-adding-the-paddles/#reacting-to-input) where I encountered this error. Feel free to check it out and run it locally to see if there's a better fix than changing the documentation here!

Without this change I get the following error:
```sh
❯ cargo run

# ...omitting output for brevity
error[E0277]: the trait bound `tetra::graphics::drawable::DrawParams: std::convert::From<&vek::vec::repr_c::vec2::Vec2<f32>>` is not satisfied
   --> src/main.rs:39:9
    |
39  |         graphics::draw(ctx, &self.paddle_texture, &self.paddle_position);
    |         ^^^^^^^^^^^^^^ the trait `std::convert::From<&vek::vec::repr_c::vec2::Vec2<f32>>` is not implemented for `tetra::graphics::drawable::DrawParams`
    |
    = help: the following implementations were found:
              <tetra::graphics::drawable::DrawParams as std::convert::From<vek::vec::repr_c::vec2::Vec2<f32>>>
    = note: required because of the requirements on the impl of `std::convert::Into<tetra::graphics::drawable::DrawParams>` for `&vek::vec::repr_c::vec2::Vec2<f32>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `pong`.

To learn more, run the command again with --verbose.
```

After making this change I'm able to build without issue.

```sh
❯ cargo run

Compiling pong v0.1.0 (/home/cbzehner/Projects/arewegameyet/tetra-tutorial)
# ...omitting output for brevity
Finished dev [unoptimized + debuginfo] target(s) in 2.65s
 Running `target/debug/pong`
```

Aside from this issue I was able to work through the tutorial without a hitch! Thanks again! :pray: 